### PR TITLE
fix: :rotating_light: add missing includes

### DIFF
--- a/include/net/socket_addr.hpp
+++ b/include/net/socket_addr.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <net/ip_addr.hpp>
 #include <string>
 #include <variant>

--- a/include/net/uri.hpp
+++ b/include/net/uri.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <map>
 #include <net/export.h>
 #include <optional>

--- a/src/ip_addr.cpp
+++ b/src/ip_addr.cpp
@@ -1,9 +1,8 @@
+#include <cstdint>
 #include <cstring>
-#include <iomanip>
 #include <limits>
 #include <net/ip_addr.hpp>
 #include <numeric>
-#include <sstream>
 #include <string>
 
 namespace {

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <net/socket.hpp>


### PR DESCRIPTION
The library would not build when using gcc:latest and adding these includes resolves the missing stdint declarations.